### PR TITLE
Add Live Visitor Counter Using PostHog

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,12 +1,6 @@
 import createMDX from "@next/mdx";
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true, experimental: {
-    reactRoot: true,
-  },
-  compiler: {
-    reactRemoveProperties: true,
-  },
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
   images: {
     domains: ["ik.imagekit.io", "thumbnails.cbsig.net", "upload.wikimedia.org"],

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,12 @@
 import createMDX from "@next/mdx";
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  reactStrictMode: true, experimental: {
+    reactRoot: true,
+  },
+  compiler: {
+    reactRemoveProperties: true,
+  },
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
   images: {
     domains: ["ik.imagekit.io", "thumbnails.cbsig.net", "upload.wikimedia.org"],

--- a/src/app/actions/getVisitorCount.ts
+++ b/src/app/actions/getVisitorCount.ts
@@ -1,0 +1,28 @@
+'use server';
+
+export async function getVisitorCount() {
+  try {
+    const response = await fetch(`https://us.posthog.com/api/projects/${process.env.POSTHOG_PROJECT_ID}/events/`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${process.env.POSTHOG_PERSONAL_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    const data = await response.json();
+
+    const recentPageviews = data.results.filter((event: any) => {
+      const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+      return event.event === '$pageview' && event.timestamp > fiveMinutesAgo;
+    });
+
+    // Count unique visitors based on distinct_id
+    const uniqueVisitors = new Set(recentPageviews.map((event: any) => event.distinct_id)).size;
+
+    return uniqueVisitors;
+  } catch (error) {
+    console.error('Error fetching events:', error);
+    return 0;
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,12 +6,10 @@ import WebUpdates from "@/features/web-updates/components";
 import ArticlesHomepage from "@/shared/components/homepage/articles";
 import HomepageHeader from "@/shared/components/homepage/header";
 import PodcastSummaryHomepage from "@/shared/components/homepage/podcast-summary";
-import VisitorCounter from "@/shared/components/visitor-counter/VisitorCounter";
 
 export default function Home() {
   return (
     <>
-        <VisitorCounter />
       <main>
         <HomepageHeader />
         <div className="w-full max-w-[1200px] mx-auto px-4 flex flex-col sm:flex-row gap-15">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,13 +6,14 @@ import WebUpdates from "@/features/web-updates/components";
 import ArticlesHomepage from "@/shared/components/homepage/articles";
 import HomepageHeader from "@/shared/components/homepage/header";
 import PodcastSummaryHomepage from "@/shared/components/homepage/podcast-summary";
+import VisitorCounter from "@/shared/components/visitor-counter/VisitorCounter";
 
 export default function Home() {
   return (
     <>
+        <VisitorCounter />
       <main>
         <HomepageHeader />
-
         <div className="w-full max-w-[1200px] mx-auto px-4 flex flex-col sm:flex-row gap-15">
           <div className="w-full sm:w-[60%] md:w-[80%]">
             <SocialMediaPostSeason />

--- a/src/shared/components/homepage/header/index.tsx
+++ b/src/shared/components/homepage/header/index.tsx
@@ -3,11 +3,15 @@ import Image from "next/image";
 import Logo from "@/assets/survivor-tribe-logo.png";
 import Navbar from "../../navbar";
 import { Button } from "../../ui/button";
-
+import VisitorCounter from "../../visitor-counter/VisitorCounter";
 const HomepageHeader = () => {
   return (
-    <header className="text-center mt-16">
+    <header className="text-center">
+
+<VisitorCounter />
+<div className="mt-14">
       <Navbar />
+      </div>
       <div className="w-full h-full min-h-[300px] flex flex-col items-center justify-center gap-5">
         <Link href="/">
           <Image src={Logo} alt="Survivor Tribe Logo" width={400} />

--- a/src/shared/components/homepage/header/index.tsx
+++ b/src/shared/components/homepage/header/index.tsx
@@ -6,7 +6,7 @@ import { Button } from "../../ui/button";
 
 const HomepageHeader = () => {
   return (
-    <header className="text-center">
+    <header className="text-center mt-16">
       <Navbar />
       <div className="w-full h-full min-h-[300px] flex flex-col items-center justify-center gap-5">
         <Link href="/">

--- a/src/shared/components/posthog-provider/index.tsx
+++ b/src/shared/components/posthog-provider/index.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useEffect, useRef } from "react";
 import posthog from "posthog-js";
 import { PostHogProvider as PostHogReactProvider } from "posthog-js/react";
 
@@ -7,15 +8,20 @@ interface PostHogProviderProps {
 }
 
 const PostHogProvider = ({ children }: PostHogProviderProps) => {
-  if (typeof window !== "undefined" && process.env.NEXT_PUBLIC_POSTHOG_KEY) {
-    posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-      api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-      person_profiles: "identified_only", // or 'always' to create profiles for anonymous users as well
-    });
-  }
-  return (
-    <PostHogReactProvider client={posthog}>{children}</PostHogReactProvider>
-  );
+  const isInitialized = useRef(false);  // Prevents re-initialization
+
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_POSTHOG_KEY && !isInitialized.current) {
+      posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+        api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://app.posthog.com",
+        autocapture: false,  // Optional: Disable DOM manipulation
+        person_profiles: "identified_only",
+      });
+      isInitialized.current = true;
+    }
+  }, []);
+
+  return <PostHogReactProvider client={posthog}>{children}</PostHogReactProvider>;
 };
 
 export default PostHogProvider;

--- a/src/shared/components/posthog-provider/index.tsx
+++ b/src/shared/components/posthog-provider/index.tsx
@@ -14,7 +14,7 @@ const PostHogProvider = ({ children }: PostHogProviderProps) => {
     if (process.env.NEXT_PUBLIC_POSTHOG_KEY && !isInitialized.current) {
       posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
         api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://app.posthog.com",
-        autocapture: false,  // Optional: Disable DOM manipulation
+        autocapture: true,
         person_profiles: "identified_only",
       });
       isInitialized.current = true;

--- a/src/shared/components/visitor-counter/VisitorCounter.tsx
+++ b/src/shared/components/visitor-counter/VisitorCounter.tsx
@@ -4,23 +4,41 @@ import { useEffect, useState } from 'react';
 import { getVisitorCount } from '../../../app/actions/getVisitorCount';
 
 const VisitorCounter = () => {
-  const [visitorCount, setVisitorCount] = useState<number>(0);
+  const [visitorCount, setVisitorCount] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchVisitorCount = async () => {
-      const count = await getVisitorCount();
-      setVisitorCount(count);
+      try {
+        const count = await getVisitorCount();
+        setVisitorCount(count);
+      } catch (err) {
+        setError('Failed to load visitor count. Please try again later.');
+      }
     };
 
     fetchVisitorCount();
-    const interval = setInterval(fetchVisitorCount, 5000);
-
-    return () => clearInterval(interval);
   }, []);
 
+  if (error) {
+    return (
+      <div className="fixed top-0 left-0 w-full text-center bg-red-500 py-2 text-lg font-bold text-white z-50 shadow-md">
+        ⚠️ {error}
+      </div>
+    );
+  }
+
+  if (visitorCount === null) {
+    return (
+      <div className="fixed top-0 left-0 w-full text-center bg-gray-400 py-2 text-lg font-bold text-white z-50 shadow-md">
+        ⏳ Loading visitor count...
+      </div>
+    );
+  }
+
   return (
-    <div className="fixed top-0 left-0 w-full text-center bg-green-400 py-2 text-lg font-bold z-50 shadow-md">
-      👀 {visitorCount} visitors are currently online!
+    <div className="fixed top-0 left-0 w-full text-center bg-blue-500 py-2 text-lg font-bold text-white z-50 shadow-md">
+      🌎 {visitorCount} people have visited this site this month!
     </div>
   );
 };

--- a/src/shared/components/visitor-counter/VisitorCounter.tsx
+++ b/src/shared/components/visitor-counter/VisitorCounter.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getVisitorCount } from '../../../app/actions/getVisitorCount';
+
+const VisitorCounter = () => {
+  const [visitorCount, setVisitorCount] = useState<number>(0);
+
+  useEffect(() => {
+    const fetchVisitorCount = async () => {
+      const count = await getVisitorCount();
+      setVisitorCount(count);
+    };
+
+    fetchVisitorCount();
+    const interval = setInterval(fetchVisitorCount, 5000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="fixed top-0 left-0 w-full text-center bg-green-400 py-2 text-lg font-bold z-50 shadow-md">
+      👀 {visitorCount} visitors are currently online!
+    </div>
+  );
+};
+
+export default VisitorCounter;


### PR DESCRIPTION
Implemented a live visitor counter feature that displays the number of active users on the landing page. The counter dynamically updates every 5 seconds by fetching real-time $pageview data from PostHog.

- Created a server action (getVisitorCount) to fetch and filter recent $pageview events from PostHog.
- Counted unique visitors using distinct_id within the last 5 minutes.
- Added a VisitorCounter component that displays the active visitor count in a banner at the top of the page.
- Integrated auto-refresh to update the visitor count every 5 seconds.